### PR TITLE
Adds a hash of the underlying HTML to parser

### DIFF
--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -1,4 +1,4 @@
-import os, argparse, csv, json, traceback
+import os, argparse, csv, json, traceback, xxhash
 from time import time
 
 from bs4 import BeautifulSoup

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -71,6 +71,13 @@ for case_html_file_name in os.listdir(case_html_path):
         else:
             case_data = post2017.parse(case_soup, case_id)
 
+        #Adds a hash to the JSON file of the underlying HTML
+        body = case_soup.find("body")
+        balance_table = body.find_all("table")[-1]
+        if "Balance Due" in balance_table.text:
+            balance_table.decompose()
+        case_data["html_hash"] = xxhash.xxh64(str(body)).hexdigest()
+        
         # Write JSON data
         with open(os.path.join(case_json_path, case_id + ".json"), "w") as file_handle:
             file_handle.write(json.dumps(case_data))

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -73,6 +73,7 @@ for case_html_file_name in os.listdir(case_html_path):
 
         #Adds a hash to the JSON file of the underlying HTML
         body = case_soup.find("body")
+        #This section removes the "balance due" table, which changes frequently with payment even if the case data itself isn't updated, so it makes the hashes look unique even when things haven't changed. 
         balance_table = body.find_all("table")[-1]
         if "Balance Due" in balance_table.text:
             balance_table.decompose()


### PR DESCRIPTION
For determining versions of files using hashes, I recommend we add a hash of the underlying HTML to the JSON file for the case as a field. It is otherwise not a step done anywhere else in this repo so far. This will later be used for creating an entry ID in CosmosDB.